### PR TITLE
Update Dart/Flutter constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.2 <3.0.0"
+  sdk: ">=3.2.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -34,20 +34,20 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
-  firebase_core: ^1.24.0
-  firebase_storage: ^10.3.11
-  cloud_firestore: ^3.5.1
-  firebase_auth: ^3.11.2
-  google_sign_in: ^5.4.2
-  flutter_riverpod: ^2.0.2
-  fpdart: ^0.3.0
-  routemaster: ^1.0.1
-  dotted_border: ^2.0.0+2
-  file_picker: ^5.2.1
-  shared_preferences: ^2.0.15
-  uuid: ^3.0.6
-  any_link_preview: ^2.0.9
+  cupertino_icons: any
+  firebase_core: any
+  firebase_storage: any
+  cloud_firestore: any
+  firebase_auth: any
+  google_sign_in: any
+  flutter_riverpod: any
+  fpdart: any
+  routemaster: any
+  dotted_border: any
+  file_picker: any
+  shared_preferences: any
+  uuid: any
+  any_link_preview: any
 
 dev_dependencies:
   flutter_test:
@@ -58,7 +58,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: any
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- update Dart SDK constraint for Flutter stable 3.32.6
- loosen dependency versions for compatibility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687089c055108321a43e60f6bf0ced0b